### PR TITLE
[build] CloudFront 배포를 위한 정적 파일 export 기능 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: ['ibb.co'],
+    formats: ['image/webp'],
+  },
+
+  output: 'export',
+
+  // i18n: {
+  //   locales: ['ko', 'en'],
+  //   defaultLocale: 'ko',
+  // },
+  // i18n은 국제화를 지원하지만, `output: 'export'`에서는 사용할 수 없어 주석 처리
 }
 
 export default nextConfig


### PR DESCRIPTION
## #️⃣연관된 이슈

#29 
## 📝작업 내용

CloundFront 배포를 위해서는 정적 파일이 필요합니다. 그 정적 파일을 S3에 export하기 위해 next.config.ts파일에 output 속성을 추가할 필요가 있어서 수정했습니다.